### PR TITLE
Corrigé coquille dans chapitre 2

### DIFF
--- a/02-getting-started.md.erb
+++ b/02-getting-started.md.erb
@@ -165,13 +165,13 @@ Pour faire court, non. À la différence de Rails, Meteor n'impose aucune struct
 
 Pardonnez notre excès de zèle. En pratique, nous n'aurons pas besoin du dossier `/public`, car Microscope n'utilisera pas de ressources statiques! Néanmoins, nous avons voulu vous signaler l'utilité de ce dossier, car la plupart des applications Meteor comprendront tout au moins quelques images.
 
-À ce propos, vous aurez peut-être observé la présence d'un dossier caché nommé `.meteor`. C'est l'emplacement où Meteor enregistre son propre code, et y apporter des modifications peut conduire à un effet potentiellement désastreux. Vous n'aurez généralement pas besoin de prêter attention à son contenu --- sinon, à de rares exceptions, aux fichiers `.meteor/packages` et `.meteor/release`, qui contiennent respectement la liste de vos paquets intelligents (_smart packages_) et la version de Meteor en usage dans votre projet. Lorsque vous ajoutez des paquets et changez de version de Meteor, vous pouvez vérifier ces changements en examinant ces deux fichiers.
+À ce propos, vous aurez peut-être observé la présence d'un dossier caché nommé `.meteor`. C'est l'emplacement où Meteor enregistre son propre code, et y apporter des modifications peut conduire à un effet potentiellement désastreux. Vous n'aurez généralement pas besoin de prêter attention à son contenu --- sinon, à de rares exceptions, aux fichiers `.meteor/packages` et `.meteor/release`, qui contiennent respectivement la liste de vos paquets intelligents (_smart packages_) et la version de Meteor en usage dans votre projet. Lorsque vous ajoutez des paquets et changez de version de Meteor, vous pouvez vérifier ces changements en examinant ces deux fichiers.
 
 <% note do %>
 
-### Tirets bas vs CasseAlternée
+### Tirets_bas vs CasseAlternée
 
-Au débat antique concernant l'usage, dans les noms d'identifiants, de tirets bas (caractère _underscore_, comme dans `ma_variable`), ou de la casse alternée (_CamelCase_, comme dans `maVariable`), nous n'ajouterons rien, sinon qu'importe la convention que vous adopterez, pourvu que vous l'appliquiez systématiquement.
+À l'antique débat concernant l'usage, dans les noms d'identifiants, de tirets bas (caractère _underscore_, comme dans `ma_variable`), ou de la casse alternée (_CamelCase_, comme dans `maVariable`), nous n'ajouterons rien, sinon qu'importe la convention que vous adopterez, pourvu que vous l'appliquiez systématiquement.
 
 Dans cet ouvrage, nous utilisons la casse alternée `camelCase`, parce que c'est l'usage avec JavaScript --- après tout, on écrit JavaScript, et non java_script!
 


### PR DESCRIPTION
- Corrigé «respectement» par «respectivement»
- Reformulé «Au débat antique» par «À l'antique débat», plus fluide à mon sens
